### PR TITLE
Implement missing mock proxy members

### DIFF
--- a/Projects/TestHarness/Mock/MockDataAccessProxy.cs
+++ b/Projects/TestHarness/Mock/MockDataAccessProxy.cs
@@ -1,3 +1,4 @@
+using System;
 using XppInterpreter.Interpreter.Proxy;
 
 namespace TestHarness.Mock
@@ -7,5 +8,12 @@ namespace TestHarness.Mock
         public void TtsBegin() { }
         public void TtsCommit() { }
         public void TtsAbort() { }
+
+        public IDisposable CreateChangeCompanyHandler(string datAreaId)
+        {
+            return null;
+        }
+
+        public void Next(object common) { }
     }
 }

--- a/Projects/TestHarness/Mock/MockExceptionsProxy.cs
+++ b/Projects/TestHarness/Mock/MockExceptionsProxy.cs
@@ -5,6 +5,10 @@ namespace TestHarness.Mock
 {
     class MockExceptionsProxy : IXppExceptionsProxy
     {
-        public void Throw(string message) => throw new Exception(message);
+        public void Throw(object obj) => throw new Exception(obj?.ToString());
+
+        public bool IsExceptionMember(Exception exception, string exceptionMember) => false;
+
+        public void SetRetryCount(int retryCount) { }
     }
 }

--- a/Projects/TestHarness/Mock/MockIntrinsicFunctionProvider.cs
+++ b/Projects/TestHarness/Mock/MockIntrinsicFunctionProvider.cs
@@ -3,6 +3,7 @@ namespace TestHarness.Mock
 {
     class MockIntrinsicFunctionProvider : XppInterpreter.Interpreter.Proxy.IIntrinsicFunctionProvider
     {
+        public Type GetCustomPredefinedFunctionProvider() => null;
         public int classNum(string name) { return default; }
         public string classStr(string name) { return default; }
         public string formStr(string name) { return default; }

--- a/Projects/TestHarness/Mock/MockQueryGenerationProxy.cs
+++ b/Projects/TestHarness/Mock/MockQueryGenerationProxy.cs
@@ -1,9 +1,21 @@
+using XppInterpreter.Interpreter;
 using XppInterpreter.Interpreter.Proxy;
+using XppInterpreter.Interpreter.Query;
+using XppInterpreter.Parser;
+using XppInterpreter.Parser.Data;
 
 namespace TestHarness.Mock
 {
     class MockQueryGenerationProxy : IXppQueryGenerationProxy
     {
-        public IQueryGenerator NewQueryGenerator() => null;
+        class DummyQueryGenerator : IQueryGenerator
+        {
+            public void ExecuteInsertRecordset(InsertRecordset insertRecordset, RuntimeContext runtimeContext) { }
+            public void ExecuteDeleteFrom(DeleteFrom deleteFrom, RuntimeContext runtimeContext) { }
+            public void ExecuteUpdateRecordset(UpdateRecordset updateRecordset, RuntimeContext runtimeContext) { }
+            public ISearchInstance NewSearchInstance(Query query, RuntimeContext runtimeContext) => null;
+        }
+
+        public IQueryGenerator NewQueryGenerator() => new DummyQueryGenerator();
     }
 }

--- a/Projects/TestHarness/Program.cs
+++ b/Projects/TestHarness/Program.cs
@@ -13,7 +13,7 @@ namespace TestHarness
     {
         static void Main(string[] args)
         {
-            string source = @"class Hello { public static str greet() { return \"hi\"; } } return Hello::greet();";
+            string source = "class Hello { public static str greet() { return \"hi\"; } } return Hello::greet();";
 
             var (proxy, reflection, functions) = BuildProxy();
             var lexer = new XppLexer(source);
@@ -21,7 +21,7 @@ namespace TestHarness
             var result = parser.Parse();
             var programAst = result.AST as XppInterpreter.Parser.Program;
 
-            var generator = new ByteCodeGenerator(proxy);
+            var generator = new ByteCodeGenerator();
             var byteCode = generator.Generate(programAst, false);
 
             foreach (var f in byteCode.DeclaredFunctions)
@@ -30,9 +30,11 @@ namespace TestHarness
             reflection.SetProxy(proxy);
 
             var interpreter = new XppInterpreter.Interpreter.XppInterpreter(proxy);
-            var interpreterResult = interpreter.Interpret(byteCode);
+            var context = new RuntimeContext(proxy, byteCode);
+            interpreter.Interpret(byteCode, context);
 
-            Console.WriteLine($"Result: {interpreterResult.Value}");
+            var resultValue = context.Stack.Count > 0 ? context.Stack.Pop() : null;
+            Console.WriteLine($"Result: {resultValue}");
         }
 
         static (XppProxy, MockReflectionProxy, Dictionary<string, RefFunction>) BuildProxy()


### PR DESCRIPTION
## Summary
- complete missing members in mock proxies to satisfy interfaces
- instantiate `ByteCodeGenerator` without arguments and run interpreter via `RuntimeContext`

## Testing
- `dotnet build Projects/XppInterpreter/XppInterpreter.csproj`
- `dotnet build Projects/TestHarness/TestHarness.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6842123224e88324bf4a937a672f7140